### PR TITLE
fix for #5 case-insensitive string comparison

### DIFF
--- a/lib/imapSimple.js
+++ b/lib/imapSimple.js
@@ -30,7 +30,7 @@ function ImapSimple(imap) {
     // special handling for `error` event
     self.imap.on('error', function (err) {
         // if .end() has been called and an 'ECONNRESET' error is received, don't bubble
-        if (err && self.ending && (err.code === 'ECONNRESET')) {
+        if (err && self.ending && (err.code.toUpperCase() === 'ECONNRESET')) {
             return;
         }
 
@@ -206,17 +206,19 @@ ImapSimple.prototype.getPartData = function (message, part, callback) {
 
                 var data = result.parts[0].body;
 
-                if (part.encoding === 'BASE64') {
+                var encoding = part.encoding.toUpperCase();
+
+                if (encoding === 'BASE64') {
                     resolve(new Buffer(data, 'base64'));
                     return;
                 }
 
-                if (part.encoding === 'QUOTED-PRINTABLE') {
+                if (encoding === 'QUOTED-PRINTABLE') {
                     resolve((new Buffer(qp.decode(data))).toString());
                     return;
                 }
 
-                if (part.encoding === '7BIT') {
+                if (encoding === '7BIT') {
                     resolve((new Buffer(data)).toString('ascii'));
                     return;
                 }


### PR DESCRIPTION
I promised it yesterday but got carried away, so here it is

I just convert the input strings to uppercase, nothing more actually, this way we can keep the uppercase version of code strings, which is indeed good for readability
