### PR TITLE
use iconv-lite to handle 8BIT messages

### DIFF
--- a/lib/imapSimple.js
+++ b/lib/imapSimple.js
@@ -7,6 +7,7 @@ var errors = require('./errors');
 var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 var qp = require('quoted-printable');
+var iconvlite = require('iconv-lite');
 
 /**
  * Constructs an instance of ImapSimple
@@ -220,6 +221,12 @@ ImapSimple.prototype.getPartData = function (message, part, callback) {
 
                 if (encoding === '7BIT') {
                     resolve((new Buffer(data)).toString('ascii'));
+                    return;
+                }
+
+                if (encoding === '8BIT') {
+                    var charset = (part.params && part.params.charset) || 'utf-8';
+                    resolve(iconvlite.decode(new Buffer(data), charset));
                     return;
                 }
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "es6-promise": "^2.0.1",
     "imap": "^0.8.14",
     "nodeify": "^1.0.0",
-    "quoted-printable": "^1.0.0"
+    "quoted-printable": "^1.0.0",
+    "iconv-lite": "~0.4.13"
   },
   "devDependencies": {
     "istanbul": "^0.3.6",


### PR DESCRIPTION
This change allows utf-8 and latin-1 messages to be decoded.
