### PR TITLE
UTF-8 support for QUOTED-PRINTABLE

### DIFF
--- a/lib/imapSimple.js
+++ b/lib/imapSimple.js
@@ -8,6 +8,7 @@ var util = require('util');
 var EventEmitter = require('events').EventEmitter;
 var qp = require('quoted-printable');
 var iconvlite = require('iconv-lite');
+var utf8 = require('utf8');
 
 /**
  * Constructs an instance of ImapSimple
@@ -215,7 +216,12 @@ ImapSimple.prototype.getPartData = function (message, part, callback) {
                 }
 
                 if (encoding === 'QUOTED-PRINTABLE') {
-                    resolve((new Buffer(qp.decode(data))).toString());
+                    if (part.params && part.params.charset &&
+                        part.params.charset.toUpperCase() === 'UTF-8') {
+                        resolve((new Buffer(utf8.decode(qp.decode(data)))).toString());
+                    } else {
+                        resolve((new Buffer(qp.decode(data))).toString());
+                    }
                     return;
                 }
 

--- a/package.json
+++ b/package.json
@@ -26,10 +26,11 @@
   },
   "dependencies": {
     "es6-promise": "^2.0.1",
+    "iconv-lite": "~0.4.13",
     "imap": "^0.8.14",
     "nodeify": "^1.0.0",
     "quoted-printable": "^1.0.0",
-    "iconv-lite": "~0.4.13"
+    "utf8": "^2.1.1"
   },
   "devDependencies": {
     "istanbul": "^0.3.6",


### PR DESCRIPTION
All gmail messages were broken, since quoted-printable library only does iso-8859-1 by default and gmail uses utf-8. Now wrapped with utf8 library if utf-8 is inside quoted-printable.
