### PR TITLE
Add/remove message flag functions, event listener functions, store seqno with messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,42 @@ message(s) in the currently open mailbox to another mailbox. `source` correspond
 specifies the messages to be moved. When completed, either calls the provided callback with signature `(err)`, or
 resolves the returned promise.
 
+- **addFlags**(<*mixed*> uid, <*string*> flag, [<*function*> callback]) - *Promise* - Adds the provided
+flag(s) to the specified message(s). `uid` is the *uid* of the message you want to add the flag to or an array of
+*uids*. `flag` is either a string or array of strings indicating the flags to add. When completed, either calls
+the provided callback with signature `(err)`, or resolves the returned promise.
+
+- **delFlags**(<*mixed*> uid, <*string*> flag, [<*function*> callback]) - *Promise* - Removes the provided
+flag(s) from the specified message(s). `uid` is the *uid* of the message you want to remove the flag from or an array of
+*uids*. `flag` is either a string or array of strings indicating the flags to remove. When completed, either calls
+the provided callback with signature `(err)`, or resolves the returned promise.
+
+## Server events
+Functions to listen to server events are configured in the configuration object that is passed to the `connect` function.
+The
+ImapSimple only implements a subset of the server event functions *node-imap* supports
+,[see here](https://github.com/mscdex/node-imap#connection-events), which are `mail`, `expunge` and `update`.
+Add them to the configuration object as follows:
+
+```
+var config = {
+    imap: {
+        ...
+    },
+    onmail: (numNewMail) => {
+      ...
+    },
+    onexpunge: (seqno) => {
+        ...
+    },
+    onupdate: (seqno, info) => {
+        ...
+    }
+};
+```
+
+For more information [see here](https://github.com/mscdex/node-imap#connection-events).
+
 ## Contributing
 Pull requests welcome! This project really needs tests, so those would be very welcome. If you have a use case you want
 supported, please feel free to add, but be sure to follow the patterns established thus far, mostly:

--- a/lib/imapSimple.js
+++ b/lib/imapSimple.js
@@ -442,6 +442,19 @@ function connect(options, callback) {
         imap.once('error', imapOnError);
         imap.once('close', imapOnClose);
         imap.once('end', imapOnEnd);
+
+        if (options.hasOwnProperty('onmail')) {
+            imap.on('mail', options.onmail);
+        }
+
+        if (options.hasOwnProperty('onexpunge')) {
+            imap.on('expunge', options.onexpunge);
+        }
+
+        if (options.hasOwnProperty('onupdate')) {
+            imap.on('update', options.onupdate);
+        }
+
         imap.connect();
     });
 }

--- a/lib/imapSimple.js
+++ b/lib/imapSimple.js
@@ -115,7 +115,7 @@ ImapSimple.prototype.openBox = function (boxName, callback) {
 ImapSimple.prototype.search = function (searchCriteria, fetchOptions, callback) {
     var self = this;
 
-    if (!callback && typeof (fetchOptions) === 'function') {
+    if (!callback && typeof fetchOptions === 'function') {
         callback = fetchOptions;
         fetchOptions = null;
     }

--- a/lib/imapSimple.js
+++ b/lib/imapSimple.js
@@ -115,7 +115,7 @@ ImapSimple.prototype.openBox = function (boxName, callback) {
 ImapSimple.prototype.search = function (searchCriteria, fetchOptions, callback) {
     var self = this;
 
-    if (!callback && typeof(fetchOptions) === 'function') {
+    if (!callback && typeof (fetchOptions) === 'function') {
         callback = fetchOptions;
         fetchOptions = null;
     }
@@ -308,6 +308,64 @@ ImapSimple.prototype.addMessageLabel = function (source, labels, callback) {
 
     return new Promise(function (resolve, reject) {
         self.imap.addLabels(source, labels, function (err) {
+            if (err) {
+                reject(err);
+                return;
+            }
+
+            resolve();
+        });
+    });
+};
+
+/**
+ * Adds the provided flag(s) to the specified message(s).
+ *
+ * @param {string|Array} uid The messages uid
+ * @param {string|Array} flags Either a single string or an array of strings indicating the flags to add to the
+ *  message(s).
+ * @param {function} [callback] Optional callback, receiving signature (err)
+ * @returns {undefined|Promise} Returns a promise when no callback is specified, resolving when the action succeeds.
+ * @memberof ImapSimple
+ */
+ImapSimple.prototype.addFlags = function (uid, flags, callback) {
+    var self = this;
+
+    if (callback) {
+        return nodeify(self.addFlags(uid, flags), callback);
+    }
+
+    return new Promise(function (resolve, reject) {
+        self.imap.addFlags(uid, flags, function (err) {
+            if (err) {
+                reject(err);
+                return;
+            }
+
+            resolve();
+        });
+    });
+};
+
+/**
+ * Removes the provided flag(s) to the specified message(s).
+ *
+ * @param {string|Array} uid The messages uid
+ * @param {string|Array} flags Either a single string or an array of strings indicating the flags to remove from the
+ *  message(s).
+ * @param {function} [callback] Optional callback, receiving signature (err)
+ * @returns {undefined|Promise} Returns a promise when no callback is specified, resolving when the action succeeds.
+ * @memberof ImapSimple
+ */
+ImapSimple.prototype.delFlags = function (uid, flags, callback) {
+    var self = this;
+
+    if (callback) {
+        return nodeify(self.delFlags(uid, flags), callback);
+    }
+
+    return new Promise(function (resolve, reject) {
+        self.imap.delFlags(uid, flags, function (err) {
             if (err) {
                 reject(err);
                 return;

--- a/lib/imapSimple.js
+++ b/lib/imapSimple.js
@@ -144,6 +144,7 @@ ImapSimple.prototype.search = function (searchCriteria, fetchOptions, callback) 
 
             function fetchOnMessage(message, seqNo) {
                 getMessage(message).then(function (message) {
+                    message.seqNo = seqNo;
                     messages[seqNo] = message;
 
                     messagesRetrieved++;


### PR DESCRIPTION
Hello,

I added wrapper functions to add and delete flags from messages, similar to the addMessageLabel function.

I also added event listener functions for receiving new mails, message updates (such as flag changes) and external message delete events. The functions are added to the config object, not sure if that is the best way to do it.

Also added to store the seqno along with messages, so we can identify messages when we receive the seqno from external delete events.

Cheers,
Dominik