### PR TITLE
Remove depedency on es6-promise

### DIFF
--- a/lib/helpers/getMessage.js
+++ b/lib/helpers/getMessage.js
@@ -1,5 +1,4 @@
 'use strict';
-var Promise = require('es6-promise').Promise;
 var Imap = require('imap');
 
 /**

--- a/lib/imapSimple.js
+++ b/lib/imapSimple.js
@@ -1,6 +1,5 @@
 'use strict';
 var Imap = require('imap');
-var Promise = require('es6-promise').Promise;
 var nodeify = require('nodeify');
 var getMessage = require('./helpers/getMessage');
 var errors = require('./errors');

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "url": "https://github.com/chadxz/imap-simple.git"
   },
   "dependencies": {
-    "es6-promise": "^4.0.3",
     "iconv-lite": "~0.4.13",
     "imap": "^0.8.18",
     "nodeify": "^1.0.0",


### PR DESCRIPTION
Promises are supported in node for a long time.
See http://node.green/#Promise