### PR TITLE
Support different encodings that are stated in the header

### DIFF
--- a/lib/helpers/encoding.js
+++ b/lib/helpers/encoding.js
@@ -6,23 +6,7 @@ module.exports = function getEncoding(body) {
 
         if (charsetString) {
             var result  = /.*charset="(.*)"/.exec(charsetString);
-            var encodingString = result[1];
-
-            switch (encodingString) {
-                case 'iso-8859-1':
-                    return 'latin1';
-                case 'ascii':
-                case 'utf8':
-                case 'utf16le':
-                case 'ucs2':
-                case 'base64':
-                case 'latin1':
-                case 'binary':
-                case 'hex':
-                    return encodingString;
-                default:
-                    return 'utf8';
-            }
+            return result ? result[1] : 'utf8';
         }
     }
 

--- a/lib/helpers/encoding.js
+++ b/lib/helpers/encoding.js
@@ -1,0 +1,30 @@
+module.exports = function getEncoding(body) {
+    if (body['content-type']) {
+        var charsetString = body['content-type'].find(function (item) {
+            return item.indexOf('charset=') === -1 ? false : true;
+        });
+
+        if (charsetString) {
+            var result  = /.*charset="(.*)"/.exec(charsetString);
+            var encodingString = result[1];
+
+            switch (encodingString) {
+                case 'iso-8859-1':
+                    return 'latin1';
+                case 'ascii':
+                case 'utf8':
+                case 'utf16le':
+                case 'ucs2':
+                case 'base64':
+                case 'latin1':
+                case 'binary':
+                case 'hex':
+                    return encodingString;
+                default:
+                    return 'utf8';
+            }
+        }
+    }
+
+    return 'utf8';
+}

--- a/lib/helpers/getMessage.js
+++ b/lib/helpers/getMessage.js
@@ -1,5 +1,6 @@
 'use strict';
 var Imap = require('imap');
+var getEncoding = require('./encoding');
 
 /**
  * Given an 'ImapMessage' from the node-imap library,
@@ -20,10 +21,10 @@ module.exports = function getMessage(message) {
         var isHeader = /^HEADER/g;
 
         function messageOnBody(stream, info) {
-            var body = '';
+            var bodyParts = [];
 
             function streamOnData(chunk) {
-                body += chunk.toString('utf8');
+                bodyParts.push(chunk);
             }
 
             stream.on('data', streamOnData);
@@ -34,12 +35,8 @@ module.exports = function getMessage(message) {
                 var part = {
                     which: info.which,
                     size: info.size,
-                    body: body
+                    bodyParts: bodyParts
                 };
-
-                if (isHeader.test(part.which)) {
-                    part.body = Imap.parseHeader(part.body);
-                }
 
                 messageParts.push(part);
             });
@@ -52,9 +49,28 @@ module.exports = function getMessage(message) {
         function messageOnEnd() {
             message.removeListener('body', messageOnBody);
             message.removeListener('attributes', messageOnAttributes);
+
+            var header = messageParts.find(function (part) {
+                return isHeader.test(part.which);
+            });
+
+            var encoding;
+
+            if (header) {
+                header.body = Imap.parseHeader(convertArrayToString(header.bodyParts, 'utf8'));
+                encoding = getEncoding(header.body);
+            }
+
             resolve({
                 attributes: attributes,
-                parts: messageParts
+                parts: messageParts.map(function (part) {
+                    if (!isHeader.test(part.which)) {
+                        part.body = convertArrayToString(part.bodyParts, encoding);
+                    }
+
+                    delete part.bodyParts;
+                    return part;
+                })
             });
         }
 
@@ -63,3 +79,10 @@ module.exports = function getMessage(message) {
         message.once('end', messageOnEnd);
     });
 };
+
+function convertArrayToString(parts, encoding) {
+    var encodedParts = parts.map(function (part) {
+        return part.toString(encoding || 'utf8');
+    });
+    return encodedParts.join('');
+}

--- a/lib/helpers/getMessage.js
+++ b/lib/helpers/getMessage.js
@@ -3,6 +3,9 @@ var Imap = require('imap');
 var iconvlite = require('iconv-lite');
 var getEncoding = require('./encoding');
 
+
+var isHeader = /^HEADER/g;
+
 /**
  * Given an 'ImapMessage' from the node-imap library,
  * retrieves the message formatted as:
@@ -19,7 +22,6 @@ module.exports = function getMessage(message) {
     return new Promise(function (resolve) {
         var attributes;
         var messageParts = [];
-        var isHeader = /^HEADER/g;
 
         function messageOnBody(stream, info) {
             var bodyParts = [];
@@ -51,27 +53,25 @@ module.exports = function getMessage(message) {
             message.removeListener('body', messageOnBody);
             message.removeListener('attributes', messageOnAttributes);
 
-            var header = messageParts.find(function (part) {
-                return isHeader.test(part.which);
-            });
-
-            var encoding;
-
-            if (header) {
-                header.body = Imap.parseHeader(convertArrayToString(header.bodyParts, 'utf8'));
-                encoding = getEncoding(header.body);
-            }
+            var encoding = getEncodingFromMessageParts(messageParts);
 
             resolve({
                 attributes: attributes,
-                parts: messageParts.map(function (part) {
-                    if (!isHeader.test(part.which)) {
-                        part.body = convertArrayToString(part.bodyParts, encoding);
-                    }
+                parts: messageParts
+                    .map(function (part) {
+                        if (isHeader.test(part.which)) {
+                            part.body = Imap.parseHeader(convertArrayToString(part.bodyParts, 'utf8'));
+                        }
+                        else {
+                            part.body = convertArrayToString(part.bodyParts, encoding);
+                        }
 
-                    delete part.bodyParts;
-                    return part;
-                })
+                        delete part.bodyParts;
+                        return part;
+                    })
+                    .sort(function (part) {
+                        return isHeader.test(part.which) ? -1 : 1
+                    })
             });
         }
 
@@ -80,6 +80,19 @@ module.exports = function getMessage(message) {
         message.once('end', messageOnEnd);
     });
 };
+
+function getEncodingFromMessageParts(messageParts) {
+    var header = messageParts.find(function (part) {
+        return isHeader.test(part.which);
+    });
+
+    if (header) {
+        var body = Imap.parseHeader(convertArrayToString(header.bodyParts, 'utf8'));
+        return getEncoding(body);
+    }
+
+    return 'utf8';
+}
 
 function convertArrayToString(parts, encoding) {
     var encodedParts = parts.map(function (part) {

--- a/lib/helpers/getMessage.js
+++ b/lib/helpers/getMessage.js
@@ -1,5 +1,6 @@
 'use strict';
 var Imap = require('imap');
+var iconvlite = require('iconv-lite');
 var getEncoding = require('./encoding');
 
 /**
@@ -82,7 +83,7 @@ module.exports = function getMessage(message) {
 
 function convertArrayToString(parts, encoding) {
     var encodedParts = parts.map(function (part) {
-        return part.toString(encoding || 'utf8');
+        return iconvlite.decode(part, encoding || 'utf8');
     });
     return encodedParts.join('');
 }

--- a/lib/helpers/getMessage.js
+++ b/lib/helpers/getMessage.js
@@ -16,9 +16,10 @@ var isHeader = /^HEADER/g;
  * }
  *
  * @param {object} message an ImapMessage from the node-imap library
+ * @param {string} [charset] optional string of the charset
  * @returns {Promise} a promise resolving to `message` with schema as described above
  */
-module.exports = function getMessage(message) {
+module.exports = function getMessage(message, charset) {
     return new Promise(function (resolve) {
         var attributes;
         var messageParts = [];
@@ -53,7 +54,7 @@ module.exports = function getMessage(message) {
             message.removeListener('body', messageOnBody);
             message.removeListener('attributes', messageOnAttributes);
 
-            var encoding = getEncodingFromMessageParts(messageParts);
+            var encoding = charset || getEncodingFromMessageParts(messageParts);
 
             resolve({
                 attributes: attributes,
@@ -96,7 +97,9 @@ function getEncodingFromMessageParts(messageParts) {
 
 function convertArrayToString(parts, encoding) {
     var encodedParts = parts.map(function (part) {
-        return iconvlite.decode(part, encoding || 'utf8');
+        var s = iconvlite.decode(part, encoding || 'utf8');
+        return s;
     });
+
     return encodedParts.join('');
 }

--- a/lib/imapSimple.js
+++ b/lib/imapSimple.js
@@ -209,17 +209,18 @@ ImapSimple.prototype.getPartData = function (message, part, callback) {
                 }
 
                 var data = result.parts[0].body;
-
                 var encoding = part.encoding.toUpperCase();
+                var charset = part.params && part.params.charset;
+                var isUTF8 = charset && charset.toUpperCase() === 'UTF-8';
 
                 if (encoding === 'BASE64') {
-                    resolve(new Buffer(data, 'base64'));
+                    var buffer = new Buffer(data, 'base64');
+                    resolve(iconvlite.decode(buffer, charset));
                     return;
                 }
 
                 if (encoding === 'QUOTED-PRINTABLE') {
-                    if (part.params && part.params.charset &&
-                        part.params.charset.toUpperCase() === 'UTF-8') {
+                    if (isUTF8) {
                         resolve((new Buffer(utf8.decode(qp.decode(data)))).toString());
                     } else {
                         resolve((new Buffer(qp.decode(data))).toString());
@@ -233,8 +234,7 @@ ImapSimple.prototype.getPartData = function (message, part, callback) {
                 }
 
                 if (encoding === '8BIT' || encoding === 'BINARY') {
-                    var charset = ((part.params && part.params.charset) || 'utf-8').toUpperCase();
-                    if (charset === 'UTF-8') {
+                    if (isUTF8) {
                         resolve(iconvlite.decode(new Buffer(data), charset));
                     } else {
                         resolve(data);

--- a/lib/imapSimple.js
+++ b/lib/imapSimple.js
@@ -155,7 +155,9 @@ ImapSimple.prototype.search = function (searchCriteria, fetchOptions, callback) 
 
             function fetchCompleted() {
                 // pare array down while keeping messages in order
-                var pared = messages.filter(function (m) { return !!m; });
+                var pared = messages.filter(function (m) {
+                    return !!m;
+                });
                 resolve(pared);
             }
 
@@ -200,7 +202,7 @@ ImapSimple.prototype.getPartData = function (message, part, callback) {
         });
 
         function fetchOnMessage(msg) {
-            getMessage(msg).then(function (result) {
+            getMessage(msg, part.params && part.params.charset).then(function (result) {
                 if (result.parts.length !== 1) {
                     reject(new Error('Got ' + result.parts.length + ' parts, should get 1'));
                     return;
@@ -231,8 +233,12 @@ ImapSimple.prototype.getPartData = function (message, part, callback) {
                 }
 
                 if (encoding === '8BIT' || encoding === 'BINARY') {
-                    var charset = (part.params && part.params.charset) || 'utf-8';
-                    resolve(iconvlite.decode(new Buffer(data), charset));
+                    var charset = ((part.params && part.params.charset) || 'utf-8').toUpperCase();
+                    if (charset === 'UTF-8') {
+                        resolve(iconvlite.decode(new Buffer(data), charset));
+                    } else {
+                        resolve(data);
+                    }
                     return;
                 }
 

--- a/test/encoding.spec.js
+++ b/test/encoding.spec.js
@@ -1,0 +1,12 @@
+'use strict';
+var expect = require("chai").expect;
+
+
+describe("imap-simple", function () {
+    var getEncoding = require("../lib/helpers/encoding");
+
+    it("correct encoding is found ", function () {
+        expect(getEncoding({ 'content-type': [ 'text/plain; charset="iso-8859-1"' ] })).to.equal('latin1');
+        expect(getEncoding({})).to.equal('utf8');
+    });
+});

--- a/test/encoding.spec.js
+++ b/test/encoding.spec.js
@@ -2,10 +2,10 @@
 var expect = require("chai").expect;
 
 
-describe("imap-simple", function () {
+describe("encoding", function () {
     var getEncoding = require("../lib/helpers/encoding");
 
-    it("correct encoding is found ", function () {
+    it("correct encoding is found", function () {
         expect(getEncoding({ 'content-type': [ 'text/plain; charset="iso-8859-1"' ] })).to.equal('iso-8859-1');
         expect(getEncoding({})).to.equal('utf8');
     });

--- a/test/encoding.spec.js
+++ b/test/encoding.spec.js
@@ -6,7 +6,7 @@ describe("imap-simple", function () {
     var getEncoding = require("../lib/helpers/encoding");
 
     it("correct encoding is found ", function () {
-        expect(getEncoding({ 'content-type': [ 'text/plain; charset="iso-8859-1"' ] })).to.equal('latin1');
+        expect(getEncoding({ 'content-type': [ 'text/plain; charset="iso-8859-1"' ] })).to.equal('iso-8859-1');
         expect(getEncoding({})).to.equal('utf8');
     });
 });

--- a/test/getMessage.spec.js
+++ b/test/getMessage.spec.js
@@ -1,0 +1,57 @@
+'use strict';
+var expect = require("chai").expect;
+var events = require('events');
+var Readable = require('stream').Readable;
+
+
+describe("getMessage", function () {
+    var getMessage = require("../lib/helpers/getMessage");
+
+    it("getMessage creates correct results", function(done) {
+        var emailEmitter = new events.EventEmitter();
+        getMessage(emailEmitter).then(function (result) {
+            expect(result.attributes).to.deep.equal(undefined);
+            expect(result.parts[0]).to.deep.equal({ which: 'HEADER', size: 0, body: expectedHeaderContent });
+            expect(result.parts[1]).to.deep.equal({ which: 'TEXT', size: 0, body: 'ÄÅ'});
+            done();
+        });
+
+        var bodyStream = new Readable;
+        emailEmitter.emit('body', bodyStream, { seqno: 0, which: 'TEXT', size: 0 });
+        bodyStream.push(new Buffer([0xC4])); // Ä in iso-8859-1
+        bodyStream.push(new Buffer([0xC5])); // Ö in iso-8859-1
+        bodyStream.push(null);
+
+        var headerStream = new Readable;
+        emailEmitter.emit('body', headerStream, { seqno: 0, which: 'HEADER', size: 0 });
+        headerStream.push(headerContent);
+        headerStream.push(null);
+
+        setTimeout(function() {
+            emailEmitter.emit('end');
+        })
+    });
+});
+
+var headerContent = [
+    'Delivered-To: delivery.address@gmail.com',
+    'Received: received 1',
+    'Received: received 2',
+    'From: sender.address@gmail.com',
+    'To: delivery.address@gmail.com',
+    'Message-ID: <123.abc@abc.com>',
+    'Subject: subject',
+    'Content-Type: text/plain; charset="iso-8859-1"',
+    'Date: Wed, 22 Mar 2017 13:10:37 +0100 (CET)'
+].join('\r\n');
+
+var expectedHeaderContent = {
+    'delivered-to': ['delivery.address@gmail.com'],
+    'received': ['received 1', 'received 2'],
+    'from': ['sender.address@gmail.com'],
+    'to': ['delivery.address@gmail.com'],
+    'message-id': ['<123.abc@abc.com>'],
+    'subject': ['subject'],
+    'content-type': ['text/plain; charset="iso-8859-1"'],
+    'date': ['Wed, 22 Mar 2017 13:10:37 +0100 (CET)']
+}


### PR DESCRIPTION
Some emails are not encoded with utf8. If they are not, it is stated at email's header like this:
Content-Type: text/plain; charset="iso-8859-1"

Pull request will check for the charset in header and use encoding defined in there. If it is missing, utf8 will be used.
 