### PR TITLE
Simple wrapper for imap.getBoxes() method.

### DIFF
--- a/lib/imapSimple.js
+++ b/lib/imapSimple.js
@@ -409,6 +409,13 @@ ImapSimple.prototype.append = function (message, options, callback) {
     });
 };
 
+/**
+ * Returns a list of mailboxes (folders).
+ *
+ *
+ * @param {function} [callback] Optional callback containing 'boxes' object.
+ * @returns {undefined|Promise} Returns a promise when no callback is specified, resolving when the action succeeds.
+ */
 
 ImapSimple.prototype.getBoxes = function (callback) {
 

--- a/lib/imapSimple.js
+++ b/lib/imapSimple.js
@@ -413,7 +413,7 @@ ImapSimple.prototype.append = function (message, options, callback) {
 ImapSimple.prototype.getBoxes = function (callback) {
 
     if (callback) {
-        return nodeify(this.getBoxes());
+        return nodeify(this.getBoxes(), callback);
     }
 
     return new Promise((resolve, reject) => {

--- a/lib/imapSimple.js
+++ b/lib/imapSimple.js
@@ -418,13 +418,14 @@ ImapSimple.prototype.append = function (message, options, callback) {
  */
 
 ImapSimple.prototype.getBoxes = function (callback) {
+    var self = this;
 
     if (callback) {
-        return nodeify(this.getBoxes(), callback);
+        return nodeify(self.getBoxes(), callback);
     }
 
-    return new Promise((resolve, reject) => {
-        this.imap.getBoxes((err, boxes) => {
+    return new Promise(function(resolve, reject)  {
+        self.imap.getBoxes(function(err, boxes) {
             if (err) {
                 reject(err);
             } else {

--- a/lib/imapSimple.js
+++ b/lib/imapSimple.js
@@ -381,9 +381,9 @@ ImapSimple.prototype.delFlags = function (uid, flags, callback) {
  *
  * @param {string|Buffer} message The messages to append to the mailbox
  * @param {object} [options]
- * @param {string} [options.mailbox] The mailbox to append the message to. 
+ * @param {string} [options.mailbox] The mailbox to append the message to.
   Defaults to the currently open mailbox.
- * @param {string|Array<String>} [options.flag] A single flag (e.g. 'Seen') or an array 
+ * @param {string|Array<String>} [options.flag] A single flag (e.g. 'Seen') or an array
   of flags (e.g. ['Seen', 'Flagged']) to append to the message. Defaults to
   no flags.
  * @param {function} [callback] Optional callback, receiving signature (err)
@@ -409,6 +409,24 @@ ImapSimple.prototype.append = function (message, options, callback) {
     });
 };
 
+
+ImapSimple.prototype.getBoxes = function (callback) {
+
+    if (callback) {
+        return nodeify(this.getBoxes());
+    }
+
+    return new Promise((resolve, reject) => {
+        this.imap.getBoxes((err, boxes) => {
+            if (err) {
+                reject(err);
+            } else {
+                resolve(boxes);
+            }
+
+        })
+    })
+};
 /**
  * Connect to an Imap server, returning an ImapSimple instance, which is a wrapper over node-imap to
  * simplify it's api for common use cases.


### PR DESCRIPTION
Simple wrapper over the getBoxes() function from node-imap.