### PR TITLE
Add functionality to add and delete mailboxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ the provided callback with signature `(err)`, or resolves the returned promise.
 
 - **append**(<*mixed*> message, [<*object*> options], [<*function*> callback]) - *Promise* - Appends the argument
 message to the currently open mailbox or another mailbox. `message` is a RFC-822 compatible MIME message. Valid `options`
-are *mailbox*, *flags* and *date*. When completed, either calls the provided callback with signature `(err)`, or resolves 
+are *mailbox*, *flags* and *date*. When completed, either calls the provided callback with signature `(err)`, or resolves
 the returned promise.
 
 - **delFlags**(<*mixed*> uid, <*string*> flag, [<*function*> callback]) - *Promise* - Removes the provided
@@ -190,7 +190,7 @@ the provided callback with signature `(err)`, or resolves the returned promise.
 - **getBoxes**([<*function*> callback]) - *Promise* - Returns the full list of mailboxes (folders). Upon success, either
 the provided callback will be called with signature `(err, boxes)`, or the returned promise will be resolved with `boxes`.
 `boxes` is the exact object returned from the node-imap *getBoxes()* result.
-  
+
 - **getPartData**(<*object*> message, <*object*> part, [<*function*> callback]) - *Promise* - Downloads part data
 (which is either part of the message body, or an attachment). Upon success, either the provided callback will be called
 with signature `(err, data)`, or the returned promise will be resolved with `data`. The data will be automatically
@@ -203,6 +203,10 @@ resolves the returned promise.
 
 - **openBox**(<*string*> boxName, [<*function*> callback]) - *Promise* - Open a mailbox, calling the provided callback
 with signature `(err, boxName)`, or resolves the returned promise with `boxName`.
+
+- **addBox**(<*string*> boxName) - *Promise* - Create a mailbox, resolves the returned promise with `boxName`.
+
+- **delBox**(<*string*> boxName) - *Promise* - Delete a mailbox, resolves the returned promise with `boxName`.
 
 - **search**(<*object*> searchCriteria, [<*object*> fetchOptions], [<*function*> callback]) - *Promise* - Search for and
 retrieve mail in the previously opened mailbox. The search is performed based on the provided `searchCriteria`, which is
@@ -221,7 +225,7 @@ body is automatically parsed into an object.
 
 ## Server events
 Functions to listen to server events are configured in the configuration object that is passed to the `connect` function.
-ImapSimple only implements a subset of the server event functions that *node-imap* supports, [see here](https://github.com/mscdex/node-imap#connection-events), 
+ImapSimple only implements a subset of the server event functions that *node-imap* supports, [see here](https://github.com/mscdex/node-imap#connection-events),
 which are `mail`, `expunge` and `update`. Add them to the configuration object as follows:
 
 ```

--- a/lib/imapSimple.js
+++ b/lib/imapSimple.js
@@ -437,6 +437,54 @@ ImapSimple.prototype.getBoxes = function (callback) {
 };
 
 /**
+ * Add new mailbox (folder)
+ *
+ * @param {string} boxName The name of the box to added
+ * @returns {undefined|Promise} Returns a promise resolving to `boxName`
+ * @memberof ImapSimple
+ */
+ImapSimple.prototype.addBox = function (boxName) {
+    var self = this;
+
+    return new Promise(function (resolve, reject) {
+
+        self.imap.addBox(boxName, function (err) {
+
+            if (err) {
+                reject(err);
+                return;
+            }
+
+            resolve(boxName);
+        });
+    });
+};
+
+/**
+ * Delete mailbox (folder)
+ *
+ * @param {string} boxName The name of the box to deleted
+ * @returns {undefined|Promise} Returns a promise resolving to `boxName`
+ * @memberof ImapSimple
+ */
+ImapSimple.prototype.delBox = function (boxName, callback) {
+    var self = this;
+
+    return new Promise(function (resolve, reject) {
+
+        self.imap.delBox(boxName, function (err) {
+
+            if (err) {
+                reject(err);
+                return;
+            }
+
+            resolve(boxName);
+        });
+    });
+};
+
+/**
  * Connect to an Imap server, returning an ImapSimple instance, which is a wrapper over node-imap to
  * simplify it's api for common use cases.
  *

--- a/lib/imapSimple.js
+++ b/lib/imapSimple.js
@@ -440,11 +440,16 @@ ImapSimple.prototype.getBoxes = function (callback) {
  * Add new mailbox (folder)
  *
  * @param {string} boxName The name of the box to added
- * @returns {undefined|Promise} Returns a promise resolving to `boxName`
+ * @param {function} [callback] Optional callback, receiving signature (err, boxName)
+ * @returns {undefined|Promise} Returns a promise when no callback is specified, resolving to `boxName`
  * @memberof ImapSimple
  */
-ImapSimple.prototype.addBox = function (boxName) {
+ImapSimple.prototype.addBox = function (boxName, callback) {
     var self = this;
+
+    if (callback) {
+        return nodeify(this.addBox(boxName), callback);
+    }
 
     return new Promise(function (resolve, reject) {
 
@@ -464,11 +469,16 @@ ImapSimple.prototype.addBox = function (boxName) {
  * Delete mailbox (folder)
  *
  * @param {string} boxName The name of the box to deleted
- * @returns {undefined|Promise} Returns a promise resolving to `boxName`
+ * @param {function} [callback] Optional callback, receiving signature (err, boxName)
+ * @returns {undefined|Promise} Returns a promise when no callback is specified, resolving to `boxName`
  * @memberof ImapSimple
  */
 ImapSimple.prototype.delBox = function (boxName, callback) {
     var self = this;
+
+    if (callback) {
+        return nodeify(this.delBox(boxName), callback);
+    }
 
     return new Promise(function (resolve, reject) {
 


### PR DESCRIPTION
For these features the underlying 'node-imap' package
does not really support callbacks.
Thus callbacks are omitted for these.

Features are just promise wrappers to
the corresponding functionality of 'node-imap'.
Usage is quite simple and straighforward.
Either promise resolves to the requested boxname
or promise is rejected with error message from 'node-imap' .