### PR TITLE
addPartData(), added uuencode support plus neccessary dependancy

### DIFF
--- a/lib/imapSimple.js
+++ b/lib/imapSimple.js
@@ -8,6 +8,7 @@ var EventEmitter = require('events').EventEmitter;
 var qp = require('quoted-printable');
 var iconvlite = require('iconv-lite');
 var utf8 = require('utf8');
+var uuencode = require('uuencode');
 
 /**
  * Constructs an instance of ImapSimple
@@ -233,6 +234,13 @@ ImapSimple.prototype.getPartData = function (message, part, callback) {
                 if (encoding === '8BIT' || encoding === 'BINARY') {
                     var charset = (part.params && part.params.charset) || 'utf-8';
                     resolve(iconvlite.decode(new Buffer(data), charset));
+                    return;
+                }
+
+                if (encoding === 'UUENCODE') {
+                    var parts = data.toString().split('\n') // remove newline characters
+                    var merged = parts.splice(1, parts.length - 4).join('') // remove excess lines and join lines with empty string
+                    resolve(uuencode.decode(merged))
                     return;
                 }
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "imap": "^0.8.18",
     "nodeify": "^1.0.0",
     "quoted-printable": "^1.0.0",
-    "utf8": "^2.1.1"
+    "utf8": "^2.1.1",
+    "uuencode": "0.0.4"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Stumbled upon this particular use case, when my attachments used uuencode (unix to unix encoding) and an error was thrown. This is a simple fix for enabling the parsing of such attachments