### PR TITLE
Added usage of Mailparser to README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,79 @@ imaps.connect(config).then(function (connection) {
 });
 ```
 
+#### Retrieve Body Content
+```js
+var imaps = require('imap-simple');
+const _ = require('lodash');
+
+var config = {
+    imap: {
+        user: 'your@email.address',
+        password: 'yourpassword',
+        host: 'imap.gmail.com',
+        port: 993,
+        tls: true,
+        authTimeout: 3000
+    }
+};
+
+imaps.connect(config).then(function (connection) {
+    return connection.openBox('INBOX').then(function () {
+        var searchCriteria = ['1:5'];
+        var fetchOptions = {
+            bodies: ['HEADER', 'TEXT'],
+        };
+        return connection.search(searchCriteria, fetchOptions).then(function (messages) {
+            messages.forEach(function (item) {
+                var all = _.find(item.parts, { "which": "TEXT" })
+                var html = (Buffer.from(all.body, 'base64').toString('ascii'));
+                console.log(html)
+            });
+        });
+    });
+});
+
+```
+
+#### Usage of Mailparser in combination with imap-simple
+```js
+var imaps = require('imap-simple');
+const simpleParser = require('mailparser').simpleParser;
+const _ = require('lodash');
+
+var config = {
+    imap: {
+        user: 'your@email.address',
+        password: 'yourpassword',
+        host: 'imap.gmail.com',
+        port: 993,
+        tls: true,
+        authTimeout: 3000
+    }
+};
+
+imaps.connect(config).then(function (connection) {
+    return connection.openBox('INBOX').then(function () {
+        var searchCriteria = ['1:5'];
+        var fetchOptions = {
+            bodies: ['HEADER', 'TEXT', ''],
+        };
+        return connection.search(searchCriteria, fetchOptions).then(function (messages) {
+            messages.forEach(function (item) {
+                var all = _.find(item.parts, { "which": "" })
+                var id = item.attributes.uid;
+                var idHeader = "Imap-Id: "+id+"\r\n";
+                simpleParser(idHeader+all.body, (err, mail) => {
+                    // access to the whole mail object
+                    console.log(mail.subject)
+                    console.log(mail.html)
+                });
+            });
+        });
+    });
+});
+```
+
 #### Download all attachments from all unread email since yesterday
 
 ```js
@@ -139,6 +212,7 @@ This is a test message
   connection.append(message.toString(), {mailbox: 'Drafts', flags: '\\Draft'});
 });
 ```
+
 
 ## API
 


### PR DESCRIPTION
Due the issue #54 there is a need to explain how html content and other attributes can easily grabbed. The provided examples makes it clear for every dev.