### PR TITLE
Feature/extract fetch messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,21 @@ body is automatically parsed into an object.
         //  }, ...]
     ```
 
+- **fetchMessages**(<*mixed*> uid,, [<*object*> fetchOptions], [<*function*> callback]) - *Promise* - Retrieve mail in 
+the currently open mailbox. `uid` is the *uid* of the message you want to add the flag to or an array of
+*uids*.  All results will be subsequently downloaded, according to the options
+provided by `fetchOptions`, which are also identical to those passed to `fetch` of [node-imap][]. Upon a successful
+fetch operation, either the provided callback will be called with signature `(err, results)`, or the returned
+promise will be resolved with `results`. The format of `results` is detailed below. See node-imap's *ImapMessage*
+signature for information about `attributes`, `which`, `size`, and `body`. For any message part that is a `HEADER`, the
+body is automatically parsed into an object.
+    ```js
+        // [{
+        //      attributes: object,
+        //      parts: [ { which: string, size: number, body: string }, ... ]
+        //  }, ...]
+    ```
+
 ## Server events
 Functions to listen to server events are configured in the configuration object that is passed to the `connect` function.
 ImapSimple only implements a subset of the server event functions that *node-imap* supports, [see here](https://github.com/mscdex/node-imap#connection-events),

--- a/lib/imapSimple.js
+++ b/lib/imapSimple.js
@@ -102,7 +102,7 @@ ImapSimple.prototype.openBox = function (boxName, callback) {
  * @memberof ImapSimple
  */
 ImapSimple.prototype.closeBox = function (autoExpunge=true, callback) {
-    var self = this;    
+    var self = this;
 
     if (typeof(autoExpunge) == 'function'){
         callback = autoExpunge;
@@ -172,43 +172,87 @@ ImapSimple.prototype.search = function (searchCriteria, fetchOptions, callback) 
                 return;
             }
 
-            var fetch = self.imap.fetch(uids, fetchOptions);
-            var messagesRetrieved = 0;
-            var messages = [];
-
-            function fetchOnMessage(message, seqNo) {
-                getMessage(message).then(function (message) {
-                    message.seqNo = seqNo;
-                    messages[seqNo] = message;
-
-                    messagesRetrieved++;
-                    if (messagesRetrieved === uids.length) {
-                        fetchCompleted();
-                    }
-                });
-            }
-
-            function fetchCompleted() {
-                // pare array down while keeping messages in order
-                var pared = messages.filter(function (m) { return !!m; });
-                resolve(pared);
-            }
-
-            function fetchOnError(err) {
-                fetch.removeListener('message', fetchOnMessage);
-                fetch.removeListener('end', fetchOnEnd);
-                reject(err);
-            }
-
-            function fetchOnEnd() {
-                fetch.removeListener('message', fetchOnMessage);
-                fetch.removeListener('error', fetchOnError);
-            }
-
-            fetch.on('message', fetchOnMessage);
-            fetch.once('error', fetchOnError);
-            fetch.once('end', fetchOnEnd);
+            self.fetchMessages(uids, fetchOptions, function (err, messages) {
+                if (err) {
+                    reject(err);
+                    return;
+                }
+                resolve(messages);
+            });
         });
+    });
+};
+
+/**
+ * Retrieve the messages given by uid.
+ *
+ * Results are in the form:
+ *
+ * [{
+ *   attributes: object,
+ *   parts: [ { which: string, size: number, body: string }, ... ]
+ * }, ...]
+ *
+ * See node-imap's ImapMessage signature for information about `attributes`, `which`, `size`, and `body`.
+ * For any message part that is a `HEADER`, the body is automatically parsed into an object.
+ *
+ * @param {string|Array} uids The messages uid
+ * @param {object} fetchOptions Criteria to use to fetch the search results. Passed to node-imap's .fetch() 1:1
+ * @param {function} [callback] Optional callback, receiving signature (err, results)
+ * @returns {undefined|Promise} Returns a promise when no callback is specified, resolving to `results`
+ * @memberof ImapSimple
+ */
+
+ImapSimple.prototype.fetchMessages = function (uids, fetchOptions, callback) {
+    var self = this;
+
+    if (!callback && typeof fetchOptions === 'function') {
+        callback = fetchOptions;
+        fetchOptions = null;
+    }
+
+    if (callback) {
+        return nodeify(this.fetchMessages(uids, fetchOptions), callback);
+    }
+
+    return new Promise(function (resolve, reject) {
+
+        var fetch = self.imap.fetch(uids, fetchOptions);
+        var messagesRetrieved = 0;
+        var messages = [];
+
+        function fetchOnMessage(message, seqNo) {
+            getMessage(message).then(function (message) {
+                message.seqNo = seqNo;
+                messages[seqNo] = message;
+
+                messagesRetrieved++;
+                if (messagesRetrieved === uids.length) {
+                    fetchCompleted();
+                }
+            });
+        }
+
+        function fetchCompleted() {
+            // pare array down while keeping messages in order
+            var pared = messages.filter(function (m) { return !!m; });
+            resolve(pared);
+        }
+
+        function fetchOnError(err) {
+            fetch.removeListener('message', fetchOnMessage);
+            fetch.removeListener('end', fetchOnEnd);
+            reject(err);
+        }
+
+        function fetchOnEnd() {
+            fetch.removeListener('message', fetchOnMessage);
+            fetch.removeListener('error', fetchOnError);
+        }
+
+        fetch.on('message', fetchOnMessage);
+        fetch.once('error', fetchOnError);
+        fetch.once('end', fetchOnEnd);
     });
 };
 


### PR DESCRIPTION
just a refactoring, provide fetchMessages() in the api and use it in search().

I didn't see a way to modify the search() method signature while keeping it backward compatible. 

btw: removing callbacks, using classes, const and arrow functions would be fun. (Node 6.4)