### PR TITLE
fix: change uid type in comments to number

### DIFF
--- a/lib/imapSimple.js
+++ b/lib/imapSimple.js
@@ -102,7 +102,7 @@ ImapSimple.prototype.openBox = function (boxName, callback) {
  * @memberof ImapSimple
  */
 ImapSimple.prototype.closeBox = function (autoExpunge=true, callback) {
-    var self = this;    
+    var self = this;
 
     if (typeof(autoExpunge) == 'function'){
         callback = autoExpunge;
@@ -363,7 +363,7 @@ ImapSimple.prototype.addMessageLabel = function (source, labels, callback) {
 /**
  * Adds the provided flag(s) to the specified message(s).
  *
- * @param {string|Array} uid The messages uid
+ * @param {number|Array} uid The messages uid
  * @param {string|Array} flags Either a single string or an array of strings indicating the flags to add to the
  *  message(s).
  * @param {function} [callback] Optional callback, receiving signature (err)
@@ -392,7 +392,7 @@ ImapSimple.prototype.addFlags = function (uid, flags, callback) {
 /**
  * Removes the provided flag(s) to the specified message(s).
  *
- * @param {string|Array} uid The messages uid
+ * @param {number|Array} uid The messages uid
  * @param {string|Array} flags Either a single string or an array of strings indicating the flags to remove from the
  *  message(s).
  * @param {function} [callback] Optional callback, receiving signature (err)
@@ -421,7 +421,7 @@ ImapSimple.prototype.delFlags = function (uid, flags, callback) {
 /**
  * Deletes the specified message(s).
  *
- * @param {string|Array} uid The uid or array of uids indicating the messages to be deleted
+ * @param {number|Array} uid The uid or array of uids indicating the messages to be deleted
  * @param {function} [callback] Optional callback, receiving signature (err)
  * @returns {undefined|Promise} Returns a promise when no callback is specified, resolving when the action succeeds.
  * @memberof ImapSimple


### PR DESCRIPTION
As the `node-imap` package says: 

> `uid` - integer - A 32-bit ID that uniquely identifies this message within its mailbox.

so `uid` is an integer but in the `imap-simple` comments it is an integer.

before this PR, I fixed the `uid` type in the `@types/imap-simple` and in this PR I fixed the `uid` type to number in the comments.